### PR TITLE
main: Use correct d-bus interface name

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ const Lang = imports.lang;
 
 const DISCOVERY_FEED_NAME = 'com.endlessm.DiscoveryFeed';
 const DISCOVERY_FEED_PATH = '/com/endlessm/DiscoveryFeed';
-const DISCOVERY_FEED_IFACE = 'com.endlessm.DiscoveryFeed.View';
+const DISCOVERY_FEED_IFACE = 'com.endlessm.DiscoveryFeed';
 const SIDE_COMPONENT_ROLE = 'eos-side-component';
 
 const KnowledgeSearchIface = '\
@@ -46,7 +46,7 @@ const KnowledgeSearchIface = '\
 
 const DiscoveryFeedIface = '\
 <node> \
-  <interface name="' + DISCOVERY_FEED_NAME + '">  \
+  <interface name="' + DISCOVERY_FEED_IFACE + '">  \
     <method name="show">  \
       <arg type="u" direction="in" name="timestamp"/>  \
     </method>  \


### PR DESCRIPTION
Previously we were binding to an interface name which wasn't
the same as what was in our introspection xml, which was causing
property updates, and thus shell integration to not work correctly

https://phabricator.endlessm.com/T16635