### PR TITLE
Make sure to populate the view on first start

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -930,6 +930,8 @@ const DiscoveryFeedApplication = new Lang.Class({
         let providers = readDiscoveryFeedProvidersInDataDirectories();
         let onProxiesInstantiated = Lang.bind(this, function(proxies) {
             Array.prototype.push.apply(this._discoveryFeedProxies, proxies);
+            populateDiscoveryFeedModelFromQueries(this._discoveryFeedCardModel,
+                                                  this._discoveryFeedProxies);
         });
         instantiateObjectsFromDiscoveryFeedProviders(connection,
                                                      'com.endlessm.DiscoveryFeedContent',


### PR DESCRIPTION
We still do the feedProxies creation non-blocking
but make sure we populate the view when we have the
results the first time.

https://phabricator.endlessm.com/T16891