### PR TITLE
main: Reset this._discoveryFeedProxies to [] in the callback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1821,9 +1821,9 @@ const DiscoveryFeedApplication = new Lang.Class({
     // Using connection, refresh discovery feed proxies
     _refreshDiscoveryFeedProxies: function(connection) {
         // Remove all proxies and start over
-        this._discoveryFeedProxies = [];
         let providers = readDiscoveryFeedProvidersInDataDirectories();
         let onProxiesInstantiated = Lang.bind(this, function(proxies) {
+            this._discoveryFeedProxies = [];
             Array.prototype.push.apply(this._discoveryFeedProxies, proxies);
             populateDiscoveryFeedModelFromQueries(this._discoveryFeedCardModel,
                                                   this._discoveryFeedProxies);


### PR DESCRIPTION
As opposed to doing it before we call the async function. Otherwise
there is a potential race condition where we call
_refreshDiscoveryFeedProxies N times and then onProxesInstantiated
is called N times after that, adding duplicate entries.

https://phabricator.endlessm.com/T17598