### PR TITLE
app store cards: always hide the d-f view when launching g-s

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1338,7 +1338,9 @@ const DiscoveryFeedAppStoreLinkCard = new Lang.Class({
         });
         this.add(card);
         card.connect('clicked', Lang.bind(this, function() {
-            (Gio.DesktopAppInfo.new('org.gnome.Software.desktop')).launch([], null);
+            let context = Gdk.AppLaunchContext.new();
+            context.set_timestamp(Gdk.CURRENT_TIME);
+            (Gio.DesktopAppInfo.new('org.gnome.Software.desktop')).launch([], context);
         }));
     }
 });


### PR DESCRIPTION
There is a case where the d-f view was not hiding when
the app center card that launches the g-s to explore
is clicked. We need to set a timestamp so that the window
manager can do the focusing correctly.

https://phabricator.endlessm.com/T17873