### PR TITLE
QuoteOfTheDay: the actual quote is in the article title field

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1389,7 +1389,7 @@ function appendDiscoveryFeedQuoteWordFromProxy(proxyBundle) {
         source: 'word-quote',
         builder: () => new Stores.DiscoveryFeedWordQuotePairStore({
             quote: new Stores.DiscoveryFeedQuoteStore({
-                quote: TextSanitization.synopsis(quote.quote),
+                quote: TextSanitization.synopsis(quote.title),
                 author: quote.author
             }),
             word: new Stores.DiscoveryFeedWordStore({


### PR DESCRIPTION
For QuoteOfTheDay we reused the article model as it has a
text field and an author field, all which is needed to
represent an actual quote.

https://phabricator.endlessm.com/T18918