### PR TITLE
WordOfDay: get part-of-speech from the app

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -960,7 +960,7 @@ const DiscoveryFeedWordQuotePair = new Lang.Class({
         this.parent(params);
 
         this.word.label = this.model.word.word;
-        this.word_description.label = '(' + this.model.word.word_type + ') ' + this.model.word.definition;
+        this.word_description.label = '(' + this.model.word.part_of_speech + ') ' + this.model.word.definition;
         this.quote.label = '"' + this.model.quote.quote + '"';
         this.quote_author.label = this.model.quote.author.toUpperCase();
 
@@ -1390,6 +1390,7 @@ function appendDiscoveryFeedQuoteWordFromProxy(proxyBundle) {
             }),
             word: new Stores.DiscoveryFeedWordStore({
                 word: word.word,
+                part_of_speech: word.part_of_speech,
                 definition: TextSanitization.synopsis(word.definition)
             })
         })

--- a/src/stores.js
+++ b/src/stores.js
@@ -58,12 +58,12 @@ const DiscoveryFeedWordStore = new Lang.Class({
                                          GObject.ParamFlags.READWRITE |
                                          GObject.ParamFlags.CONSTRUCT_ONLY,
                                          ''),
-        word_type: GObject.ParamSpec.string('word-type',
-                                            '',
-                                            '',
-                                            GObject.ParamFlags.READWRITE |
-                                            GObject.ParamFlags.CONSTRUCT_ONLY,
-                                            ''),
+        part_of_speech: GObject.ParamSpec.string('part-of-speech',
+                                                 '',
+                                                 '',
+                                                 GObject.ParamFlags.READWRITE |
+                                                 GObject.ParamFlags.CONSTRUCT_ONLY,
+                                                 ''),
         definition: GObject.ParamSpec.string('definition',
                                              '',
                                              '',


### PR DESCRIPTION
Get the part-of-speech from the query. Change property name
accordingly to the naming in the service and data model.

This is a fix needed for https://phabricator.endlessm.com/T18919