### PR TITLE
Evergreen cards: apply design tweaks

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -53,8 +53,7 @@
 }
 
 .subcard {
-  padding: 20px;
-  margin: 20px;
+  padding: 22px;
   background-color: white;
 }
 

--- a/data/word-quote-pair.ui
+++ b/data/word-quote-pair.ui
@@ -13,6 +13,7 @@
         <property name="visible">True</property>
         <property name="hexpand">True</property>
         <property name="halign">fill</property>
+        <property name="spacing">22</property>
         <style>
           <class name="subcard-layout"/>
         </style>
@@ -20,13 +21,15 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="halign">fill</property>
+            <property name="vexpand">False</property>
+            <property name="width_request">322</property>
+            <property name="margin_left">70</property>
             <style>
               <class name="subcard"/>
             </style>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="vexpand">True</property>
                 <property name="valign">fill</property>
                 <property name="orientation">vertical</property>
                 <child>
@@ -46,6 +49,9 @@
                     <property name="hexpand">True</property>
                     <property name="xalign">0.0</property>
                     <property name="wrap">True</property>
+                    <property name="lines">4</property>
+                    <property name="width_chars">12</property>
+                    <property name="max_width_chars">12</property>
                     <style>
                       <class name="quote"/>
                     </style>
@@ -70,13 +76,15 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="halign">fill</property>
+            <property name="vexpand">False</property>
+            <property name="width_request">322</property>
+            <property name="margin_right">70</property>
             <style>
               <class name="subcard"/>
             </style>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="vexpand">True</property>
                 <property name="valign">fill</property>
                 <property name="orientation">vertical</property>
                 <child>
@@ -106,6 +114,9 @@
                     <property name="hexpand">True</property>
                     <property name="xalign">0.0</property>
                     <property name="wrap">True</property>
+                    <property name="lines">4</property>
+                    <property name="width_chars">12</property>
+                    <property name="max_width_chars">12</property>
                     <style>
                       <class name="word-description"/>
                     </style>


### PR DESCRIPTION
- the cards should have a max width of 322px each
- the spacing should be 22px
- the height of the cards is determined by the
  larger height card
- padding is 22px

https://phabricator.endlessm.com/T18919