### PR TITLE
Add GSetting to enable additional content by languages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,14 @@ service_in_files = \
 	data/com.endlessm.DiscoveryFeed.service.in \
         $(NULL)
 
+gsettings_SCHEMAS = data/com.endlessm.DiscoveryFeed.gschema.xml
+
+%.gschema.xml: %.gschema.xml.in Makefile
+	$(AM_V_GEN) sed -e 's|@GETTEXT_PACKAGE[@]|$(GETTEXT_PACKAGE)|g' \
+	$< > $@ || rm $@
+
+@GSETTINGS_RULES@
+
 # Tests
 javascript_tests = \
 	tests/js/testDiscoveryFeed.js \
@@ -39,6 +47,7 @@ EXTRA_DIST = \
 	src/com.endlessm.DiscoveryFeed.in \
 	src/com.endlessm.DiscoveryFeed.src.gresource.xml \
 	data/com.endlessm.DiscoveryFeed.data.gresource.xml \
+	data/com.endlessm.DiscoveryFeed.gschema.xml \
 	$(NULL)
 
 data/com.endlessm.DiscoveryFeed.service: $(srcdir)/data/com.endlessm.DiscoveryFeed.service.in
@@ -73,6 +82,7 @@ CLEANFILES = \
 	$(resource_DATA) \
 	$(service_DATA) \
 	src/com.endlessm.DiscoveryFeed \
+	$(gsettings_SCHEMAS) \
 	$(NULL)
 
 #  Run tests when running 'make check'

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,9 @@ AC_PROG_LN_S
 # Set up libtool
 LT_INIT
 
+# GSettings schema
+GLIB_GSETTINGS
+
 # Set up GObject-Introspection
 GOBJECT_INTROSPECTION_CHECK([1.30.0])
 

--- a/data/com.endlessm.DiscoveryFeed.gschema.xml.in
+++ b/data/com.endlessm.DiscoveryFeed.gschema.xml.in
@@ -1,0 +1,11 @@
+<schemalist gettext-domain="@GETTEXT_PACKAGE@">
+  <schema id="com.endlessm.DiscoveryFeed" path="/com/endlessm/DiscoveryFeed/">
+    <key name="force-additional-languages" type="as">
+      <default>[]</default>
+      <summary>Additional languages for which content will be aggregated in the feed.</summary>
+      <description>
+        With this setting you can enable content from the languages specified. This is in addition to the current locale for which content will always be shown. The content providers specify the language the content is in.
+      </description>
+    </key>
+  </schema>
+</schemalist>

--- a/src/main.js
+++ b/src/main.js
@@ -214,7 +214,11 @@ function readDiscoveryFeedProvidersInDirectory(directory) {
     let enumerator = null;
     let info = null;
     let providerBusDescriptors = [];
-    let languages = GLib.get_language_names();
+
+    let systemLanguages = GLib.get_language_names();
+    let settings = new Gio.Settings({ schema_id: 'com.endlessm.DiscoveryFeed' });
+    let contentLanguages = settings.get_strv('force-additional-languages');
+    let languages = systemLanguages.concat(contentLanguages);
 
     try {
         enumerator = directory.enumerate_children('standard::name,standard::type',


### PR DESCRIPTION
The setting allows to specify languages for which content
will be aggregated in the feed. This is additional to
the system language.

https://phabricator.endlessm.com/T19314