### PR TITLE
Video cards: do not expect a synopsis from the knowledge service

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1345,7 +1345,6 @@ function appendVideoCardsFromShardsAndItems(shards, items, proxy, type) {
                 source: proxy.desktopId,
                 model: new Stores.DiscoveryFeedKnowledgeAppVideoCardStore({
                     title: entry.title,
-                    synopsis: TextSanitization.synopsis(entry.synopsis),
                     thumbnail: thumbnail,
                     desktop_id: proxy.desktopId,
                     bus_name: proxy.busName,


### PR DESCRIPTION
The knowledge service does not return a synopsis for
video objects.

https://phabricator.endlessm.com/T20651