### PR TITLE
T18896: Add support for first_date model property

### DIFF
--- a/data/app-content-description.ui
+++ b/data/app-content-description.ui
@@ -84,5 +84,17 @@
         </style>
       </object>
     </child>
+    <child>
+      <object class="GtkLabel" id="date-label">
+        <property name="visible">False</property>
+        <property name="hexpand">True</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <style>
+          <class name="small-header" />
+          <class name="dark-text" />
+        </style>
+      </object>
+    </child>
   </template>
 </interface>

--- a/data/app-content-description.ui
+++ b/data/app-content-description.ui
@@ -63,7 +63,7 @@
         <property name="halign">start</property>
         <property name="xalign">0</property>
         <property name="wrap">True</property>
-	<property name="ellipsize">end</property>
+        <property name="ellipsize">end</property>
         <property name="lines">3</property>
         <style>
           <class name="title"/>
@@ -77,7 +77,7 @@
         <property name="halign">start</property>
         <property name="xalign">0</property>
         <property name="wrap">True</property>
-	<property name="ellipsize">end</property>
+        <property name="ellipsize">end</property>
         <property name="lines">3</property>
         <style>
           <class name="synopsis"/>

--- a/data/application.css
+++ b/data/application.css
@@ -8,6 +8,7 @@
 .content .synopsis {
   font-size: 12pt;
   font-family: 'Merriweather', regular;
+  margin-bottom: 10px;
 }
 
 .content .article {

--- a/data/application.css
+++ b/data/application.css
@@ -22,6 +22,10 @@
   color: #2E6C7F;
 }
 
+.dark-text {
+  color: #243239;
+}
+
 .underline {
   background-color: #5b8291;
   margin-right: 218px;

--- a/src/main.js
+++ b/src/main.js
@@ -587,6 +587,12 @@ const DiscoveryFeedAppContentDescription = new Lang.Class({
                                         GObject.ParamFlags.READWRITE |
                                         GObject.ParamFlags.CONSTRUCT_ONLY,
                                         ''),
+        formatted_date: GObject.ParamSpec.string('formatted-date',
+                                                 '',
+                                                 '',
+                                                 GObject.ParamFlags.READWRITE |
+                                                 GObject.ParamFlags.CONSTRUCT_ONLY,
+                                                 ''),
         synopsis: GObject.ParamSpec.string('synopsis',
                                            '',
                                            '',
@@ -598,7 +604,8 @@ const DiscoveryFeedAppContentDescription = new Lang.Class({
     Children: [
         'app-label',
         'title-label',
-        'synopsis-label'
+        'synopsis-label',
+        'date-label'
     ],
 
     _init: function(params) {
@@ -606,6 +613,10 @@ const DiscoveryFeedAppContentDescription = new Lang.Class({
         this.app_label.label = this.app_name;
         this.title_label.label = this.title;
         this.synopsis_label.label = this.synopsis;
+
+        // Not visible unless a date is actually set
+        this.date_label.visible = !!this.formatted_date
+        this.date_label.label = this.formatted_date
     }
 });
 
@@ -931,7 +942,10 @@ const DiscoveryFeedKnowledgeArtworkCard = new Lang.Class({
         return new DiscoveryFeedAppContentDescription({
             title: this.model.title,
             synopsis: 'by ' + this.model.author,
-            app_name: 'Masterpiece of the Day'.toUpperCase()
+            app_name: 'Masterpiece of the Day'.toUpperCase(),
+            // Need to use a ternary here since this.model.date can be an empty
+            // string
+            formatted_date: this.model.first_date ? String(new Date(this.model.first_date).getFullYear()) : null
         });
     },
 
@@ -1371,6 +1385,7 @@ function appendArtworkCardsFromShardsAndItems(shards, items, proxy, type, direct
                 model: new Stores.DiscoveryFeedKnowledgeArtworkCardStore({
                     title: entry.title,
                     author: entry.author,
+                    first_date: entry.first_date,
                     thumbnail: thumbnail,
                     desktop_id: proxy.desktopId,
                     bus_name: proxy.busName,

--- a/src/stores.js
+++ b/src/stores.js
@@ -208,7 +208,13 @@ const DiscoveryFeedKnowledgeArtworkCardStore = new Lang.Class({
                                          '',
                                          GObject.ParamFlags.READWRITE |
                                          GObject.ParamFlags.CONSTRUCT_ONLY,
-                                         '')
+                                         ''),
+        first_date: GObject.ParamSpec.string('first-date',
+                                             '',
+                                             '',
+                                             GObject.ParamFlags.READWRITE |
+                                             GObject.ParamFlags.CONSTRUCT_ONLY,
+                                             '')
     },
 
     _init: function(params) {


### PR DESCRIPTION
This is set on the DiscoveryFeedArtwork cards to show the
publication date of the artwork, which makes sense to display
in the feed (pending some design feedback).

https://phabricator.endlessm.com/T18896