### PR TITLE
js: Use var instead of const for exported names

### DIFF
--- a/src/imageCoverFrame.js
+++ b/src/imageCoverFrame.js
@@ -14,7 +14,7 @@ const WidgetSurfaceCache = imports.widgetSurfaceCache;
  * space it is allocated and then centered.
  *
  */
-const ImageCoverFrame = new Lang.Class({ // eslint-disable-line no-unused-vars
+var ImageCoverFrame = new Lang.Class({ // eslint-disable-line no-unused-vars
     Name: 'ImageCoverFrame',
     Extends: Gtk.Widget,
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -9,16 +9,16 @@ const GObject = imports.gi.GObject;
 
 const Lang = imports.lang; 
 
-const CARD_STORE_TYPE_ARTICLE_CARD = 0;
-const CARD_STORE_TYPE_WORD_QUOTE_CARD = 1;
-const CARD_STORE_TYPE_ARTWORK_CARD = 2;
-const CARD_STORE_TYPE_AVAILABLE_APPS = 3;
-const CARD_STORE_TYPE_VIDEO_CARD = 4;
-const CARD_STORE_TYPE_NEWS_CARD = 5;
-const CARD_STORE_TYPE_MAX = CARD_STORE_TYPE_NEWS_CARD;
+var CARD_STORE_TYPE_ARTICLE_CARD = 0;
+var CARD_STORE_TYPE_WORD_QUOTE_CARD = 1;
+var CARD_STORE_TYPE_ARTWORK_CARD = 2;
+var CARD_STORE_TYPE_AVAILABLE_APPS = 3;
+var CARD_STORE_TYPE_VIDEO_CARD = 4;
+var CARD_STORE_TYPE_NEWS_CARD = 5;
+var CARD_STORE_TYPE_MAX = CARD_STORE_TYPE_NEWS_CARD;
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedCardStore = new Lang.Class({
+var DiscoveryFeedCardStore = new Lang.Class({
     Name: 'DiscoveryFeedCardStore',
     Extends: GObject.Object,
     Properties: {
@@ -34,7 +34,7 @@ const DiscoveryFeedCardStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedAppCardStore = new Lang.Class({
+var DiscoveryFeedAppCardStore = new Lang.Class({
     Name: 'DiscoveryFeedAppCardStore',
     Extends: DiscoveryFeedCardStore,
     Properties: {
@@ -48,7 +48,7 @@ const DiscoveryFeedAppCardStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedWordStore = new Lang.Class({
+var DiscoveryFeedWordStore = new Lang.Class({
     Name: 'DiscoveryFeedWordStore',
     Extends: GObject.Object,
     Properties: {
@@ -74,7 +74,7 @@ const DiscoveryFeedWordStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedQuoteStore = new Lang.Class({
+var DiscoveryFeedQuoteStore = new Lang.Class({
     Name: 'DiscoveryFeedQuoteStore',
     Extends: GObject.Object,
     Properties: {
@@ -94,7 +94,7 @@ const DiscoveryFeedQuoteStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedWordQuotePairStore = new Lang.Class({
+var DiscoveryFeedWordQuotePairStore = new Lang.Class({
     Name: 'DiscoveryFeedQuotePairStore',
     Extends: DiscoveryFeedCardStore,
     Properties: {
@@ -118,17 +118,17 @@ const DiscoveryFeedWordQuotePairStore = new Lang.Class({
     }
 });
 
-const LAYOUT_DIRECTION_IMAGE_FIRST = 0;
-const LAYOUT_DIRECTION_IMAGE_LAST = 1;
+var LAYOUT_DIRECTION_IMAGE_FIRST = 0;
+var LAYOUT_DIRECTION_IMAGE_LAST = 1;
 
-const THUMBNAIL_SIZE_APP_STORE = 180;
-const THUMBNAIL_WIDTH_APP_STORE_LINK = 211;  // eslint-disable-line no-unused-vars
-const THUMBNAIL_SIZE_ARTICLE = 254;
-const THUMBNAIL_SIZE_NEWS = 322;  // eslint-disable-line no-unused-vars
-const THUMBNAIL_SIZE_ARTWORK = 400;
+var THUMBNAIL_SIZE_APP_STORE = 180;
+var THUMBNAIL_WIDTH_APP_STORE_LINK = 211;  // eslint-disable-line no-unused-vars
+var THUMBNAIL_SIZE_ARTICLE = 254;
+var THUMBNAIL_SIZE_NEWS = 322;  // eslint-disable-line no-unused-vars
+var THUMBNAIL_SIZE_ARTWORK = 400;
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedKnowledgeAppCardStore = new Lang.Class({
+var DiscoveryFeedKnowledgeAppCardStore = new Lang.Class({
     Name: 'DiscoveryFeedKnowledgeAppCardStore',
     Extends: DiscoveryFeedAppCardStore,
     Properties: {
@@ -199,7 +199,7 @@ const DiscoveryFeedKnowledgeAppCardStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedKnowledgeArtworkCardStore = new Lang.Class({
+var DiscoveryFeedKnowledgeArtworkCardStore = new Lang.Class({
     Name: 'DiscoveryFeedKnowledgeArtworkCardStore',
     Extends: DiscoveryFeedKnowledgeAppCardStore,
     Properties: {
@@ -224,7 +224,7 @@ const DiscoveryFeedKnowledgeArtworkCardStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedKnowledgeAppVideoCardStore = new Lang.Class({
+var DiscoveryFeedKnowledgeAppVideoCardStore = new Lang.Class({
     Name: 'DiscoveryFeedKnowledgeAppVideoCardStore',
     Extends: DiscoveryFeedKnowledgeAppCardStore,
     Properties: {
@@ -243,7 +243,7 @@ const DiscoveryFeedKnowledgeAppVideoCardStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedAvailableAppsStore = new Lang.Class({
+var DiscoveryFeedAvailableAppsStore = new Lang.Class({
     Name: 'DiscoveryFeedAvailableAppsStore',
     Extends: DiscoveryFeedCardStore,
 
@@ -254,13 +254,13 @@ const DiscoveryFeedAvailableAppsStore = new Lang.Class({
     }
 });
 
-const DISCOVERY_FEED_APP_TYPE_BASIC = 0;
-const DISCOVERY_FEED_APP_TYPE_DETAILED = 1;
-const DISCOVERY_FEED_APP_TYPE_APP_STORE_LINK = 2;
-const DISCOVERY_FEED_APP_TYPE_MAX = DISCOVERY_FEED_APP_TYPE_APP_STORE_LINK;
+var DISCOVERY_FEED_APP_TYPE_BASIC = 0;
+var DISCOVERY_FEED_APP_TYPE_DETAILED = 1;
+var DISCOVERY_FEED_APP_TYPE_APP_STORE_LINK = 2;
+var DISCOVERY_FEED_APP_TYPE_MAX = DISCOVERY_FEED_APP_TYPE_APP_STORE_LINK;
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedAppStore = new Lang.Class({
+var DiscoveryFeedAppStore = new Lang.Class({
     Name: 'DiscoveryFeedAppStore',
     Extends: GObject.Object,
     Properties: {
@@ -302,7 +302,7 @@ const DiscoveryFeedAppStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedAppStoreLinkStore = new Lang.Class({
+var DiscoveryFeedAppStoreLinkStore = new Lang.Class({
     Name: 'DiscoveryFeedAppStoreLinkStore',
     Extends: DiscoveryFeedAppStore,
 
@@ -318,7 +318,7 @@ const DiscoveryFeedAppStoreLinkStore = new Lang.Class({
 });
 
 // eslint-disable-next-line no-unused-vars
-const DiscoveryFeedInstallableAppStore = new Lang.Class({
+var DiscoveryFeedInstallableAppStore = new Lang.Class({
     Name: 'DiscoveryFeedInstallableAppStore',
     Extends: DiscoveryFeedAppStore,
     Properties: {

--- a/src/widgetSurfaceCache.js
+++ b/src/widgetSurfaceCache.js
@@ -15,7 +15,7 @@ const Lang = imports.lang;
  *
  * Careful with this helper, only cache surfaces you know will not update!
  */
-const WidgetSurfaceCache = new Lang.Class({ // eslint-disable-line no-unused-vars
+var WidgetSurfaceCache = new Lang.Class({ // eslint-disable-line no-unused-vars
     Name: 'WidgetSurfaceCache',
     Extends: GObject.Object,
 


### PR DESCRIPTION
This is now required by the Gjs ES6 transition.

https://phabricator.endlessm.com/T21259