### PR TITLE
T21520: Flatpak the Discovery Feed

### DIFF
--- a/build-flatpak.sh
+++ b/build-flatpak.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+set -x
+rm -rf files var metadata export build
+
+BRANCH=${BRANCH:-master}
+GIT_CLONE_BRANCH=${GIT_CLONE_BRANCH:-HEAD}
+RUN_TESTS=${RUN_TESTS:-false}
+
+sed \
+  -e "s|@BRANCH@|${BRANCH}|g" \
+  -e "s|@GIT_CLONE_BRANCH@|${GIT_CLONE_BRANCH}|g" \
+  -e "s|\"@RUN_TESTS@\"|${RUN_TESTS}|g" \
+  com.endlessm.DiscoveryFeed.json.in \
+  > com.endlessm.DiscoveryFeed.json
+
+flatpak-builder build com.endlessm.DiscoveryFeed.json
+flatpak build-export repo build ${BRANCH}
+flatpak build-bundle repo com.endlessm.DiscoveryFeed.flatpak com.endlessm.DiscoveryFeed

--- a/com.endlessm.DiscoveryFeed.json.in
+++ b/com.endlessm.DiscoveryFeed.json.in
@@ -1,0 +1,46 @@
+{
+    "app-id": "com.endlessm.DiscoveryFeed",
+    "build-options": {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "command": "com.endlessm.DiscoveryFeed",
+    "finish-args": [
+        "--socket=x11",
+        "--share=ipc",
+        "--system-talk-name=com.endlessm.Metrics",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--filesystem=/var/lib/flatpak:ro",
+        "--filesystem=/var/cache/gnome-software:ro",
+        "--filesystem=/var/endless-extra/flatpak:ro",
+        "--filesystem=host:ro",
+        "--own-name=com.endlessm.DiscoveryFeed",
+        "--talk-name=ca.desrt.dconf",
+        "--talk-name=com.endlessm.EknServices2.SearchProviderV2",
+        "--talk-name=com.endlessm.EknServices.SearchProviderV1",
+        "--talk-name=org.gnome.Software",
+        "--talk-name=org.gnome.Shell",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--command=com.endlessm.DiscoveryFeed"
+    ],
+    "modules": [
+        {
+            "name": "eos-discovery-feed",
+            "run-tests": "@RUN_TESTS@",
+            "sources": [
+                {
+                    "branch": "@GIT_CLONE_BRANCH@",
+                    "path": ".",
+                    "type": "git"
+                }
+            ]
+        }
+    ],
+    "runtime": "com.endlessm.apps.Platform",
+    "runtime-version": "3",
+    "sdk": "com.endlessm.apps.Sdk"
+}

--- a/src/main.js
+++ b/src/main.js
@@ -203,10 +203,40 @@ function allRelevantDataDirs() {
     GLib.build_filenamev([directory, 'exports', 'share'])
   )).concat(['/run/host/usr/share']))).values()];
 }
+
+//
+// flatpakCompatibleDesktopInfo
+//
+// Build a GDesktopAppInfo object for a .desktop file that might
+// be in the exports directory but is not necessarily executable
+// because the binary was not mounted in the bwrap jail.
+function flatpakCompatibleDesktopInfo(desktopId) {
+  for (let directory of allRelevantDataDirs()) {
+    let path = GLib.build_filenamev([directory, 'applications', desktopId]);
+    let keyfile = new GLib.KeyFile();
+
+    try {
+        keyfile.load_from_file(path, GLib.KeyFileFlags.NONE);
+    } catch(e) {
+        continue;
+    }
+
+    // Now that we have the keyfile, set the Exec line to some
+    // well-known binary, so that GDesktopAppInfo doesn't trip up
+    // when we try to read it.
+    keyfile.set_string(GLib.KEY_FILE_DESKTOP_GROUP,
+                       GLib.KEY_FILE_DESKTOP_KEY_EXEC,
+                       '/bin/true');
+    return Gio.DesktopAppInfo.new_from_keyfile(keyfile);
+  };
+
+  return null;
+}
+
 //
 // appLanguage
 function appLanguage(desktopId) {
-    let appInfo = Gio.DesktopAppInfo.new(desktopId);
+    let appInfo = flatpakCompatibleDesktopInfo(desktopId);
     if (!appInfo) {
         // This case shouldn't happen - the app id passed must always
         // be valid.
@@ -327,18 +357,6 @@ function readDiscoveryFeedProvidersInDirectory(directory) {
     return providerBusDescriptors;
 }
 
-function flatpakSystemDir() {
-  return GLib.getenv('EOS_DISCOVERY_FEED_FLATPAK_SYSTEM_DIR') || '/var/lib/flatpak';
-}
-
-/* We need to look in the flatpak directories explicitly,
- * since XDG_DATA_DIRS is set by flatpak itself. */
-function allRelevantDataDirs() {
-  return GLib.get_system_data_dirs().concat([
-    GLib.build_filenamev([flatpakSystemDir(), 'exports', 'share'])
-  ]);
-}
-
 function readDiscoveryFeedProvidersInDataDirectories() {
     let dataDirectories = allRelevantDataDirs();
     return dataDirectories.reduce((allProviders, directory) => {
@@ -452,9 +470,16 @@ function recordMetricsEvent(eventId, payload) {
 //
 // Try to load a specific EknURI in a knowledge app, opening the app
 // itself if that fails.
-function loadKnowledgeAppContent(app, knowledgeSearchProxy, uri, contentType, timestamp) {
+function loadKnowledgeAppContent(app,
+                                 knowledgeSearchProxy,
+                                 shellProxy,
+                                 uri,
+                                 contentType,
+                                 timestamp) {
+    let desktopId = app.get_id();
+
     recordMetricsEvent(EVENT_DISCOVERY_FEED_CLICK, new GLib.Variant('a{ss}', {
-        app_id: app.get_id(),
+        app_id: desktopId,
         content_type: contentType
     }));
 
@@ -462,15 +487,24 @@ function loadKnowledgeAppContent(app, knowledgeSearchProxy, uri, contentType, ti
     context.set_timestamp(timestamp);
 
     if (!knowledgeSearchProxy) {
-        app.launch([], context);
+        log('Without a known search proxy, app ' + desktopId + ' cannot be launched directly');
         return;
     }
 
     knowledgeSearchProxy.LoadItemRemote(uri, '', timestamp, function(result, excp) {
         if (!excp)
             return;
-        logError(excp, 'Could not load app with article ' + uri + ' fallback to just launch the app, trace');
-        app.launch([], context);
+        logError(excp,
+                 'Could not load app with article ' +
+                 uri +
+                 ' fallback to just launch the app through the shell, trace');
+        shellProxy.LaunchRemote(desktopId, timestamp, function(result, excp) {
+            if (!excp)
+              return;
+
+            logError(excp,
+                     'Failed to launch app ' + desktopId + ' through the shell');
+        });
     });
 }
 
@@ -509,11 +543,15 @@ function createMetaCallProxy(interfaceMetadata, callFunc, callFuncSync) {
 //
 // Create a proxy for a DBus object which calls methods through the shell's
 // AppLauncher interface.
-function createShellAppLauncherMetaCallProxy(interfaceMetadata,
-                                             appId,
-                                             busName,
-                                             objectPath,
-                                             interfaceName) {
+//
+// Returns an object containing the raw shell proxy, shellProxy and
+// the meta-call proxy metaProxy. Use object destructuring to pick the
+// ones you need.
+function createShellAppLauncherMetaCallProxies(interfaceMetadata,
+                                               appId,
+                                               busName,
+                                               objectPath,
+                                               interfaceName) {
     let interfaceWrapper = Gio.DBusProxy.makeProxyWrapper(AppLauncherIface);
     let onProxyReady = function(initable, error) {
         if (error) {
@@ -549,10 +587,15 @@ function createShellAppLauncherMetaCallProxy(interfaceMetadata,
                                                 wrapped,
                                                 args);
     };
-    return createMetaCallProxy(interfaceMetadata, asyncCallFunc, syncCallFunc);
+    let proxy = createMetaCallProxy(interfaceMetadata, asyncCallFunc, syncCallFunc);
+
+    return {
+        metaProxy: proxy,
+        shellProxy
+    };
 }
 
-// createSearchProxyFromObjectPath
+// createSearchProxiesFromObjectPath
 //
 // Using the given object path, create a proxy object for it asynchronously.
 //
@@ -561,13 +604,13 @@ function createShellAppLauncherMetaCallProxy(interfaceMetadata,
 // so that launching the app will show a splash-screen. However, it should
 // have similar semantics to a proxy created using makeProxyWrapper - you
 // should be able to use it transparently.
-function createSearchProxyFromObjectPath(appId, objectPath) {
+function createSearchProxiesFromObjectPath(appId, objectPath) {
     if (objectPath) {
-        return createShellAppLauncherMetaCallProxy(KnowledgeSearchIface,
-                                                   appId,
-                                                   appId,
-                                                   objectPath,
-                                                   KNOWLEDGE_SEARCH_INTERFACE_NAME);
+        return createShellAppLauncherMetaCallProxies(KnowledgeSearchIface,
+                                                     appId,
+                                                     appId,
+                                                     objectPath,
+                                                     KNOWLEDGE_SEARCH_INTERFACE_NAME);
     }
 
     return null;
@@ -877,7 +920,7 @@ const DiscoveryFeedKnowledgeAppCard = new Lang.Class({
 
         // Read the desktop file and then set the app icon and label
         // appropriately
-        this._app = Gio.DesktopAppInfo.new(this.model.desktop_id);
+        this._app = flatpakCompatibleDesktopInfo(this.model.desktop_id);
         let card = new DiscoveryFeedActivatableFrame({
             content: this.createLayout()
         });
@@ -885,12 +928,19 @@ const DiscoveryFeedKnowledgeAppCard = new Lang.Class({
         card.connect('clicked', Lang.bind(this, function() {
             loadKnowledgeAppContent(this._app,
                                     this._knowledgeSearchProxy,
+                                    this._shellAppLauncherProxy,
                                     this.model.uri,
                                     this.contentType,
                                     Gtk.get_current_event_time());
         }));
-        this._knowledgeSearchProxy = createSearchProxyFromObjectPath(this.model.knowledge_app_id,
-                                                                     this.model.knowledge_search_object_path);
+
+        let {
+            metaProxy,
+            shellProxy
+        } = createSearchProxiesFromObjectPath(this.model.knowledge_app_id,
+                                              this.model.knowledge_search_object_path);
+        this._knowledgeSearchProxy = metaProxy;
+        this._shellAppLauncherProxy = shellProxy;
     },
 
     createLayout: function() {
@@ -1083,6 +1133,20 @@ const DiscoveryFeedAppStoreLinkCard = new Lang.Class({
     _init: function(params) {
         this.parent(params);
 
+        let interfaceWrapper = Gio.DBusProxy.makeProxyWrapper(AppLauncherIface);
+        let onProxyReady = function(initable, error) {
+            if (error) {
+                logError(error,
+                         'Could not create proxy for ' + SHELL_OBJECT_PATH);
+                return;
+            }
+        };
+        let shellProxy = interfaceWrapper(Gio.DBus.session,
+                                          SHELL_BUS_NAME,
+                                          SHELL_OBJECT_PATH,
+                                          onProxyReady);
+
+
         let card = new DiscoveryFeedActivatableFrame({
             content: new DiscoveryFeedContentCardLayout({
                 content: new DiscoveryFeedContentPreview({
@@ -1099,9 +1163,17 @@ const DiscoveryFeedAppStoreLinkCard = new Lang.Class({
         });
         this.add(card);
         card.connect('clicked', Lang.bind(this, function() {
-            let context = Gdk.AppLaunchContext.new();
-            context.set_timestamp(Gtk.get_current_event_time());
-            (Gio.DesktopAppInfo.new('org.gnome.Software.desktop')).launch([], context);
+            // We can't use g_desktop_app_info_launch to launch
+            // GNOME-Software directly, instead use the shell's
+            // interface to do that
+            shellProxy.LaunchRemote('org.gnome.Software.desktop',
+                                    Gtk.get_current_event_time(),
+                                    (result, excp) => {
+                                        if (!excp)
+                                            return;
+                                        logError(excp,
+                                                 'Could not launch org.gnome.Software');
+                                    });
         }));
     }
 });

--- a/src/main.js
+++ b/src/main.js
@@ -227,7 +227,17 @@ function flatpakCompatibleDesktopInfo(desktopId) {
     keyfile.set_string(GLib.KEY_FILE_DESKTOP_GROUP,
                        GLib.KEY_FILE_DESKTOP_KEY_EXEC,
                        '/bin/true');
-    return Gio.DesktopAppInfo.new_from_keyfile(keyfile);
+
+    // Need to override the get_id function here - creating the desktop
+    // file with g_desktop_app_info_new_from_keyfile does not set
+    // the underlying desktop_id and there is no way to set it after
+    // construction.
+    let app_info = Gio.DesktopAppInfo.new_from_keyfile(keyfile);
+    app_info.get_id = function() {
+        return desktopId;
+    };
+
+    return app_info;
   };
 
   return null;


### PR DESCRIPTION
This is a trial run of flatpaking the Discovery Feed. So far, it actually seems to work quite well, given that we don't actually need to talk to all bus names in reality, but only EknServices, the org.gnome.Shell and org.gnome.Software. We lucked out on a lot of our usage of `GDesktopAppInfo`, since we were already launching through the shell's app launcher proxy anyway.

https://phabricator.endlessm.com/T21520