### PR TITLE
T22367: Use SoupURI instead of GFile to parse the thumbnail URI

### DIFF
--- a/com.endlessm.DiscoveryFeed.json.in
+++ b/com.endlessm.DiscoveryFeed.json.in
@@ -20,6 +20,7 @@
         "--filesystem=host:ro",
         "--own-name=com.endlessm.DiscoveryFeed",
         "--talk-name=ca.desrt.dconf",
+        "--talk-name=com.endlessm.EknServices3.SearchProviderV3",
         "--talk-name=com.endlessm.EknServices2.SearchProviderV2",
         "--talk-name=com.endlessm.EknServices.SearchProviderV1",
         "--talk-name=org.gnome.Software",

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ GLIB_COMPILE_RESOURCES=`$PKG_CONFIG --variable glib_compile_resources gio-2.0`
 AC_PATH_PROG([GJS],[gjs])
 
 # Checks for libraries.
-PKG_CHECK_MODULES(EOS_DISCOVERY_FEED, [eos-shard-0 glib-2.0 gio-2.0 gobject-2.0 gio-unix-2.0 gtk+-3.0])
+PKG_CHECK_MODULES(EOS_DISCOVERY_FEED, [eos-shard-0 glib-2.0 gio-2.0 gobject-2.0 gio-unix-2.0 gtk+-3.0 libsoup-2.4])
 
 # Checks for header files.
 

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends: debhelper (>= 9),
                libgirepository1.0-dev,
                libglib2.0-bin,
                libglib2.0-dev,
+               libsoup2.4-dev,
                pkg-config,
                python-lcov-cobertura (>= 1.5)
 Standards-Version: 3.9.4


### PR DESCRIPTION
The former method was not robust to URIs that only had two slashes in them.

https://phabricator.endlessm.com/T22367