### PR TITLE
store-provider: Handle total URI parsing failure by treating URI as a path

### DIFF
--- a/libfeed/feed-store-provider.c
+++ b/libfeed/feed-store-provider.c
@@ -135,8 +135,15 @@ static gchar *
 remove_uri_prefix (const gchar *uri)
 {
   g_autoptr(SoupURI) soup_uri = soup_uri_new (uri);
-  const gchar *path = soup_uri_get_path (soup_uri);
+  const gchar *path = NULL;
 
+  if (soup_uri == NULL)
+    {
+      g_message ("Expected %s to be a URI, but it was not, continuing anyway", uri);
+      return strip_leading_slashes (uri);
+    }
+
+  path = soup_uri_get_path (soup_uri);
   return strip_leading_slashes (path);
 }
 


### PR DESCRIPTION
Also complain, since this shouldn't happen.

https://phabricator.endlessm.com/T22367