### PR TITLE
main: Don't call parseDuration on the already parsed duration

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -595,14 +595,12 @@ const DiscoveryFeedVideoCardLayout = new Lang.Class({
                                         GObject.ParamFlags.READWRITE |
                                         GObject.ParamFlags.CONSTRUCT_ONLY,
                                         ''),
-        duration: GObject.ParamSpec.int('duration',
-                                        '',
-                                        '',
-                                        GObject.ParamFlags.READWRITE |
-                                        GObject.ParamFlags.CONSTRUCT_ONLY,
-                                        0,
-                                        GLib.MAXINT32,
-                                        0),
+        duration: GObject.ParamSpec.string('duration',
+                                           '',
+                                           '',
+                                           GObject.ParamFlags.READWRITE |
+                                           GObject.ParamFlags.CONSTRUCT_ONLY,
+                                           ''),
         app_name: GObject.ParamSpec.string('app-name',
                                            '',
                                            '',

--- a/src/main.js
+++ b/src/main.js
@@ -624,7 +624,7 @@ const DiscoveryFeedVideoCardLayout = new Lang.Class({
 
         this.title_label.label = this.title;
         this.app_label.label = this.app_name;
-        this.duration.label = parseDuration(this.duration);
+        this.duration.label = this.duration;
     }
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -622,7 +622,7 @@ const DiscoveryFeedVideoCardLayout = new Lang.Class({
 
         this.title_label.label = this.title;
         this.app_label.label = this.app_name;
-        this.duration.label = this.duration;
+        this.duration_label.label = this.duration;
     }
 });
 


### PR DESCRIPTION
We do that in libfeed now

https://phabricator.endlessm.com/T22397