### PR TITLE
async-tasks: Add a all_tasks_results_closure_maybe_return_on_idle_if_not_tasks func

### DIFF
--- a/libfeed/feed-store-provider.c
+++ b/libfeed/feed-store-provider.c
@@ -789,6 +789,9 @@ append_discovery_feed_word_quote_from_proxies (EosDiscoveryFeedKnowledgeAppProxy
                                  cancellable,
                                  individual_task_result_completed,
                                  individual_task_result_closure_new (all_tasks_closure));
+
+  if (!all_tasks_results_has_tasks_remaining (all_tasks_closure))
+    all_tasks_results_return_now (all_tasks_closure);
 }
 
 static void
@@ -864,6 +867,9 @@ unordered_card_arrays_from_queries (GPtrArray           *ka_proxies,
                                                      individual_task_result_completed,
                                                      individual_task_result_closure_new (all_tasks_closure));
     }
+
+  if (!all_tasks_results_has_tasks_remaining (all_tasks_closure))
+    all_tasks_results_return_now (all_tasks_closure);
 }
 
 static void


### PR DESCRIPTION
This function should be called by anyone setting up an array of
async tasks to be executed in parallel to let the system know that
we are done adding tasks and that it should return on the next
idle if no tasks were added.

https://phabricator.endlessm.com/T22398