### PR TITLE
Drop dependency on eos-node-modules, disable lint & coverage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,6 @@ Priority: standard
 Maintainer: Sam Spilsbury <sam@endlessm.com>
 Build-Depends: debhelper (>= 9),
                dh-autoreconf,
-               eos-node-modules-dev (>= 1.0.0),
                gettext,
                gir1.2-libcontentfeed-0,
                gjs,


### PR DESCRIPTION
eos-node-modules is being removed as it now has little reason to exist.

Unfortunately this means that lint and coverage checks will be deactivated
(the configure macros will detect the lack of lint/coverage deps and behave
accordingly) but this could be reworked if discovery-feed development
restarts again in future.

https://phabricator.endlessm.com/T25302