### PR TITLE
tests: Relax card ordering check

### DIFF
--- a/tests/js/testModelOrdering.js
+++ b/tests/js/testModelOrdering.js
@@ -264,9 +264,9 @@ describe('Model ordering', function() {
             }
         ]);
         let arranged = arrange_with_installable_apps(models);
-        expect(arranged.map(descriptor => descriptor.builder().desktop_id)).toEqual([
-            'a', 'b', 'c', 'c'
-        ]);
+        let arr1 = ['a', 'b', 'c', 'c'];
+        expect(arranged.map(descriptor => descriptor.builder().desktop_id)).toEqual(jasmine.arrayContaining(arr1));
+        expect(arranged.length).toEqual(arr1.length);
     });
     it('doesnt repeat content app cards at all', function() {
         let models = addBuilders([
@@ -296,9 +296,9 @@ describe('Model ordering', function() {
             }
         ]);
         let arranged = arrange_with_installable_apps(models);
-        expect(arranged.map(descriptor => descriptor.builder().desktop_id)).toEqual([
-            'a', 'b', 'c'
-        ]);
+        let arr1 = ['a', 'b', 'c'];
+        expect(arranged.map(descriptor => descriptor.builder().desktop_id)).toEqual(jasmine.arrayContaining(arr1));
+        expect(arranged.length).toEqual(arr1.length)
     });
     it('splices in word/quote card in second position', function() {
         let models = addBuilders([


### PR DESCRIPTION
Following tests started failing due to change in the way content
is pushed in GHashTable and later looked up. g_hash_table_iter_next
used to return the object in the manner it was inserted in the table
before but now is no longer true (also, the order wasn't guaranteed).

Failing tests:
1) "eventually take many news cards from the same app"
2) "doesnt repeat content app cards at all"

It looks like we can relax the ordering for these tests as it doesn't
affect the ordering of the card types. It mainly addresses to avoid
redundancy between the same type of cards as far as I can see. Hence,
relax the ordering check for these tests and make it pass.

https://phabricator.endlessm.com/T26331